### PR TITLE
Commit 01

### DIFF
--- a/Assets/Scenes/Lobby.unity
+++ b/Assets/Scenes/Lobby.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641258, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -180,6 +180,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uB0B4\uB824\uCC0D\uAE30"
+    ClassType: 
     itemID: 9
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 58e81ff14ea6c254db47989f2da77323, type: 3}
@@ -211,6 +212,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -519,7 +521,7 @@ GameObject:
   - component: {fileID: 4758993}
   m_Layer: 0
   m_Name: Slot (4)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -692,7 +694,7 @@ GameObject:
   - component: {fileID: 53135214}
   m_Layer: 0
   m_Name: Slot (6)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1745,7 +1747,7 @@ GameObject:
   - component: {fileID: 154523693}
   m_Layer: 0
   m_Name: Slot (9)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -1821,7 +1823,7 @@ GameObject:
   - component: {fileID: 158701161}
   m_Layer: 0
   m_Name: Slot (1)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2151,6 +2153,86 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 180822960}
   m_CullTransparentMesh: 1
+--- !u!1 &185339612
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 185339613}
+  - component: {fileID: 185339615}
+  - component: {fileID: 185339614}
+  m_Layer: 0
+  m_Name: Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &185339613
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185339612}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2003517537}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 5, y: 2}
+  m_SizeDelta: {x: 33.1, y: 35}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &185339614
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185339612}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 1
+--- !u!222 &185339615
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 185339612}
+  m_CullTransparentMesh: 1
 --- !u!1 &197360133
 GameObject:
   m_ObjectHideFlags: 0
@@ -2164,7 +2246,7 @@ GameObject:
   - component: {fileID: 197360135}
   m_Layer: 0
   m_Name: Slot (9)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2320,7 +2402,7 @@ GameObject:
   - component: {fileID: 215137490}
   m_Layer: 0
   m_Name: Slot (2)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -2440,6 +2522,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Buff_Tower
+    ClassType: 
     itemID: 7
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 3815db486757d6f419874d58bb1f364b, type: 3}
@@ -2479,6 +2562,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -2670,133 +2754,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 254330587}
   m_CullTransparentMesh: 1
---- !u!1 &258883095
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 258883096}
-  - component: {fileID: 258883100}
-  - component: {fileID: 258883099}
-  - component: {fileID: 258883098}
-  - component: {fileID: 258883097}
-  m_Layer: 0
-  m_Name: Item(Clone) (1)
-  m_TagString: Item
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &258883096
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258883095}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0.2, y: 0.1666667, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1254533343}
-  - {fileID: 416926267}
-  - {fileID: 811692102}
-  m_Father: {fileID: 927651792}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 100}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &258883097
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258883095}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 50ae85c95785e694d8e55eb9067f21e5, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  item:
-    itemName: "\uB0B4\uB824\uCC0D\uAE30"
-    itemID: 9
-    itemDesc: Text
-    itemIcon: {fileID: 21300000, guid: 58e81ff14ea6c254db47989f2da77323, type: 3}
-    itemModel: {fileID: 7570805014596217275, guid: ae48745f78ef46b478a6e9debebf5e0e, type: 3}
-    itemValue: 1
-    itemType: 1
-    itemWeight: 0
-    maxStack: 99
-    indexItemInList: 1
-    rarity: 100
-    itemAttributes:
-    - attributeName: ATK
-      attributeValue: 5
-    - attributeName: CoolTime
-      attributeValue: 3
-    specialPrefabs: []
-    buffDatas: []
---- !u!114 &258883098
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258883095}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 551ac6c5596767544a4e04bdb7790f32, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  item:
-    itemName: 
-    itemID: 0
-    itemDesc: 
-    itemIcon: {fileID: 0}
-    itemModel: {fileID: 0}
-    itemValue: 1
-    itemType: 0
-    itemWeight: 0
-    maxStack: 5
-    indexItemInList: 99
-    rarity: 0
-    itemAttributes: []
-    specialPrefabs: []
-    buffDatas: []
-  itemTypeOfSlot: 
-  duplication: {fileID: 0}
---- !u!114 &258883099
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258883095}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 46874ca1f39c47447ad8a3b3733922f0, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
---- !u!225 &258883100
-CanvasGroup:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 258883095}
-  m_Enabled: 1
-  m_Alpha: 1
-  m_Interactable: 1
-  m_BlocksRaycasts: 1
-  m_IgnoreParentGroups: 0
 --- !u!1 &267105491
 GameObject:
   m_ObjectHideFlags: 0
@@ -3156,6 +3113,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 296494264}
   m_CullTransparentMesh: 1
+--- !u!1 &344985870
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 344985871}
+  - component: {fileID: 344985873}
+  - component: {fileID: 344985872}
+  m_Layer: 0
+  m_Name: ItemIcon
+  m_TagString: ItemIcon
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &344985871
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 344985870}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2003517537}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &344985872
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 344985870}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 21300000, guid: c2986e027f97f284dbe90a522238b6ea, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &344985873
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 344985870}
+  m_CullTransparentMesh: 1
 --- !u!1 &345871692
 GameObject:
   m_ObjectHideFlags: 0
@@ -3309,6 +3342,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Cannon_Tower
+    ClassType: 
     itemID: 5
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 725f10fa9ac647d49a51f7de95f02b3d, type: 3}
@@ -3342,6 +3376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -3603,7 +3638,7 @@ GameObject:
   - component: {fileID: 376312039}
   m_Layer: 0
   m_Name: Slot (3)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -3723,6 +3758,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uD720\uC708\uB4DC"
+    ClassType: Warrior
     itemID: 10
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 49b1324fe9983f44382c52acd0d35f20, type: 3}
@@ -3754,6 +3790,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -4135,86 +4172,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 415669912}
   m_CullTransparentMesh: 1
---- !u!1 &416926266
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 416926267}
-  - component: {fileID: 416926269}
-  - component: {fileID: 416926268}
-  m_Layer: 0
-  m_Name: Text
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &416926267
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 416926266}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 258883096}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 5, y: 2}
-  m_SizeDelta: {x: 33.1, y: 35}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &416926268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 416926266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_FontData:
-    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
-    m_FontStyle: 0
-    m_BestFit: 0
-    m_MinSize: 10
-    m_MaxSize: 40
-    m_Alignment: 4
-    m_AlignByGeometry: 0
-    m_RichText: 1
-    m_HorizontalOverflow: 0
-    m_VerticalOverflow: 0
-    m_LineSpacing: 1
-  m_Text: 1
---- !u!222 &416926269
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 416926266}
-  m_CullTransparentMesh: 1
 --- !u!1 &426573417
 GameObject:
   m_ObjectHideFlags: 0
@@ -4419,6 +4376,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uAC80\uAE30"
+    ClassType: 
     itemID: 11
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: ff81aacd3eb896d419ddf5171547b453, type: 3}
@@ -4450,6 +4408,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -4622,6 +4581,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Cannon_Tower
+    ClassType: 
     itemID: 5
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 725f10fa9ac647d49a51f7de95f02b3d, type: 3}
@@ -4655,6 +4615,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -4894,6 +4855,7 @@ MonoBehaviour:
   mainInventory: 1
   ItemsInInventory:
   - itemName: "\uB9C8\uAD6C\uD718\uB450\uB974\uAE30"
+    ClassType: 
     itemID: 8
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: a49d70bc38fde7a4f95890a7ca766ef1, type: 3}
@@ -4912,6 +4874,7 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uAC80\uAE30"
+    ClassType: 
     itemID: 11
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: ff81aacd3eb896d419ddf5171547b453, type: 3}
@@ -4930,6 +4893,7 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uB0B4\uB824\uCC0D\uAE30"
+    ClassType: 
     itemID: 9
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 58e81ff14ea6c254db47989f2da77323, type: 3}
@@ -4948,6 +4912,7 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uD720\uC708\uB4DC"
+    ClassType: 
     itemID: 10
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 49b1324fe9983f44382c52acd0d35f20, type: 3}
@@ -5541,7 +5506,7 @@ GameObject:
   - component: {fileID: 563511636}
   m_Layer: 0
   m_Name: Slot (4)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -5984,7 +5949,7 @@ GameObject:
   - component: {fileID: 588019363}
   m_Layer: 0
   m_Name: Slot (3)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6061,7 +6026,7 @@ GameObject:
   - component: {fileID: 591009599}
   m_Layer: 0
   m_Name: Slot
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6257,6 +6222,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Minion_Tower
+    ClassType: 
     itemID: 6
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 127205e58a99ce04cab49b7eebb3f43b, type: 3}
@@ -6293,6 +6259,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -6511,7 +6478,7 @@ GameObject:
   - component: {fileID: 649751200}
   m_Layer: 0
   m_Name: Slot (8)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6682,6 +6649,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 485348091}
+  - {fileID: 1251542679}
   - {fileID: 4151785054912816565}
   - {fileID: 4764110604354475165}
   - {fileID: 4534138355680637865}
@@ -6769,7 +6737,7 @@ GameObject:
   - component: {fileID: 661052828}
   m_Layer: 0
   m_Name: Slot (7)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -6889,6 +6857,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uD720\uC708\uB4DC"
+    ClassType: 
     itemID: 10
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 49b1324fe9983f44382c52acd0d35f20, type: 3}
@@ -6920,6 +6889,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -6972,7 +6942,7 @@ GameObject:
   - component: {fileID: 676099264}
   m_Layer: 0
   m_Name: Slot (8)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -7442,6 +7412,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Minion_Tower
+    ClassType: 
     itemID: 6
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 127205e58a99ce04cab49b7eebb3f43b, type: 3}
@@ -7478,6 +7449,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -7531,7 +7503,7 @@ GameObject:
   - component: {fileID: 702990706}
   m_Layer: 0
   m_Name: Slot (1)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -7608,7 +7580,7 @@ GameObject:
   - component: {fileID: 712415485}
   m_Layer: 0
   m_Name: Slot (1)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -7808,6 +7780,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uB9C8\uAD6C\uD718\uB450\uB974\uAE30"
+    ClassType: 
     itemID: 8
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: a49d70bc38fde7a4f95890a7ca766ef1, type: 3}
@@ -7839,6 +7812,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -8074,6 +8048,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 765038048}
   m_CullTransparentMesh: 1
+--- !u!1 &797853694
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 797853695}
+  - component: {fileID: 797853697}
+  - component: {fileID: 797853696}
+  m_Layer: 0
+  m_Name: SlotCover
+  m_TagString: ItemIcon
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &797853695
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797853694}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2003517537}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 55, y: 55}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &797853696
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797853694}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &797853697
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 797853694}
+  m_CullTransparentMesh: 1
 --- !u!1 &804349315
 GameObject:
   m_ObjectHideFlags: 0
@@ -8149,82 +8199,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 804349315}
-  m_CullTransparentMesh: 1
---- !u!1 &811692101
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 811692102}
-  - component: {fileID: 811692104}
-  - component: {fileID: 811692103}
-  m_Layer: 0
-  m_Name: SlotCover
-  m_TagString: ItemIcon
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &811692102
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 811692101}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 258883096}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 55, y: 95}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &811692103
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 811692101}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 0}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 0}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &811692104
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 811692101}
   m_CullTransparentMesh: 1
 --- !u!1 &815685762
 GameObject:
@@ -8624,7 +8598,7 @@ GameObject:
   - component: {fileID: 848820070}
   m_Layer: 0
   m_Name: Slot (4)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -8992,6 +8966,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Buff_Tower
+    ClassType: 
     itemID: 7
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 3815db486757d6f419874d58bb1f364b, type: 3}
@@ -9031,6 +9006,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -9083,7 +9059,7 @@ GameObject:
   - component: {fileID: 900485627}
   m_Layer: 0
   m_Name: Slot
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -9313,7 +9289,7 @@ GameObject:
   - component: {fileID: 909352122}
   m_Layer: 0
   m_Name: Slot (1)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -9480,7 +9456,7 @@ GameObject:
   - component: {fileID: 927651793}
   m_Layer: 0
   m_Name: Slot (2)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -9497,7 +9473,7 @@ RectTransform:
   m_LocalScale: {x: 3, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 258883096}
+  - {fileID: 1063857900}
   m_Father: {fileID: 17086750269763360}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9764,7 +9740,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 654707144}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
@@ -10063,7 +10039,7 @@ GameObject:
   - component: {fileID: 987916678}
   m_Layer: 0
   m_Name: Slot
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -10079,8 +10055,7 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 3, y: 4, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children:
-  - {fileID: 1063857900}
+  m_Children: []
   m_Father: {fileID: 17086750269763360}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -10397,7 +10372,7 @@ GameObject:
   - component: {fileID: 1027772338}
   m_Layer: 0
   m_Name: Slot (2)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -10610,7 +10585,7 @@ RectTransform:
   - {fileID: 1656668051}
   - {fileID: 1093533882}
   - {fileID: 1667657373}
-  m_Father: {fileID: 987916677}
+  m_Father: {fileID: 927651792}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
@@ -10632,6 +10607,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uB9C8\uAD6C\uD718\uB450\uB974\uAE30"
+    ClassType: Warrior
     itemID: 8
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: a49d70bc38fde7a4f95890a7ca766ef1, type: 3}
@@ -10663,6 +10639,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -10795,7 +10772,7 @@ GameObject:
   - component: {fileID: 1081378813}
   m_Layer: 0
   m_Name: Slot (2)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -10915,6 +10892,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Guard_Tower
+    ClassType: 
     itemID: 4
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: c51f4ee40eac21346b6ea34182cf3465, type: 3}
@@ -10948,6 +10926,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -12196,7 +12175,7 @@ GameObject:
   - component: {fileID: 1216208439}
   m_Layer: 0
   m_Name: Slot (4)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -12316,6 +12295,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: Guard_Tower
+    ClassType: 
     itemID: 4
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: c51f4ee40eac21346b6ea34182cf3465, type: 3}
@@ -12349,6 +12329,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -12401,7 +12382,7 @@ GameObject:
   - component: {fileID: 1232510144}
   m_Layer: 0
   m_Name: Slot (3)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -12874,6 +12855,126 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1250321182}
   m_CullTransparentMesh: 1
+--- !u!1 &1251542678
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1251542679}
+  - component: {fileID: 1251542682}
+  - component: {fileID: 1251542681}
+  - component: {fileID: 1251542680}
+  m_Layer: 5
+  m_Name: Inherence_Inventory
+  m_TagString: MainInventory
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1251542679
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251542678}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 654707144}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 120.6, y: 1.5}
+  m_SizeDelta: {x: 1647.9, y: 1038}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1251542680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251542678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b7d07694f7771cf498a6d1b9bc22793f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &1251542681
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251542678}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2f72b0b95ec50ed4ba70ca962fa13b99, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  prefabCanvasWithPanel: {fileID: 654707143}
+  prefabSlot: {fileID: 1880794650}
+  prefabSlotContainer: {fileID: 426573417}
+  prefabItem: {fileID: 100002, guid: 8beb0b8751c81ea4e9f32ea69a6856c3, type: 3}
+  prefabDraggingItemContainer: {fileID: 4151785056381523517}
+  prefabPanel: {fileID: 1251542678}
+  slotSize: 55
+  iconSize: 80
+  paddingBetweenX: 5
+  paddingBetweenY: 5
+  paddingLeft: 0
+  paddingRight: 0
+  paddingBottom: 0
+  paddingTop: 0
+  positionNumberX: 5
+  positionNumberY: 2
+  itemDatabase: {fileID: 11400000, guid: 964f317a23cc9f0418bb3778fccd8ebb, type: 2}
+  inventoryTitle: 
+  PanelRectTransform: {fileID: 1251542679}
+  PanelImage: {fileID: 0}
+  SlotContainer: {fileID: 426573417}
+  DraggingItemContainer: {fileID: 0}
+  SlotContainerRectTransform: {fileID: 426573418}
+  SlotGridLayout: {fileID: 426573419}
+  SlotGridRectTransform: {fileID: 426573418}
+  mainInventory: 1
+  ItemsInInventory:
+  - itemName: "\uACE0\uC720 \uC2A4\uD0AC"
+    ClassType: 
+    itemID: 9
+    itemDesc: Text
+    itemIcon: {fileID: 21300000, guid: c2986e027f97f284dbe90a522238b6ea, type: 3}
+    itemModel: {fileID: 8936188002352116344, guid: 005bc3c502863684e85138a865b0ae55, type: 3}
+    itemValue: 1
+    itemType: 2
+    itemWeight: 0
+    maxStack: 99
+    indexItemInList: -1
+    rarity: 100
+    itemAttributes:
+    - attributeName: ATK
+      attributeValue: 80
+    - attributeName: CoolTime
+      attributeValue: 6
+    specialPrefabs: []
+    buffDatas: []
+  height: 4
+  width: 4
+  stackable: 1
+--- !u!222 &1251542682
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1251542678}
+  m_CullTransparentMesh: 1
 --- !u!1 &1254123711
 GameObject:
   m_ObjectHideFlags: 0
@@ -12887,7 +12988,7 @@ GameObject:
   - component: {fileID: 1254123713}
   m_Layer: 0
   m_Name: Slot (7)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -12949,82 +13050,6 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1254123711}
-  m_CullTransparentMesh: 1
---- !u!1 &1254533342
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 1254533343}
-  - component: {fileID: 1254533345}
-  - component: {fileID: 1254533344}
-  m_Layer: 0
-  m_Name: ItemIcon
-  m_TagString: ItemIcon
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!224 &1254533343
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254533342}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 258883096}
-  m_RootOrder: 0
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0.5, y: 0.5}
-  m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 100, y: 150}
-  m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &1254533344
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254533342}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_RaycastTarget: 1
-  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
-  m_Maskable: 1
-  m_OnCullStateChanged:
-    m_PersistentCalls:
-      m_Calls: []
-  m_Sprite: {fileID: 21300000, guid: 58e81ff14ea6c254db47989f2da77323, type: 3}
-  m_Type: 0
-  m_PreserveAspect: 0
-  m_FillCenter: 1
-  m_FillMethod: 4
-  m_FillAmount: 1
-  m_FillClockwise: 1
-  m_FillOrigin: 0
-  m_UseSpriteMesh: 0
-  m_PixelsPerUnitMultiplier: 1
---- !u!222 &1254533345
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1254533342}
   m_CullTransparentMesh: 1
 --- !u!1 &1254700943
 GameObject:
@@ -13229,7 +13254,7 @@ GameObject:
   - component: {fileID: 1267207776}
   m_Layer: 0
   m_Name: Slot (5)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -14032,7 +14057,7 @@ GameObject:
   - component: {fileID: 1311021601}
   m_Layer: 0
   m_Name: Slot (8)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -14216,7 +14241,7 @@ GameObject:
   - component: {fileID: 1313771804}
   m_Layer: 0
   m_Name: Slot (9)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -14368,7 +14393,7 @@ GameObject:
   - component: {fileID: 1331418177}
   m_Layer: 0
   m_Name: Slot (7)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -14600,7 +14625,7 @@ GameObject:
   - component: {fileID: 1375771036}
   m_Layer: 0
   m_Name: Slot (6)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15132,7 +15157,7 @@ GameObject:
   - component: {fileID: 1454392977}
   m_Layer: 0
   m_Name: Slot (1)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15286,7 +15311,7 @@ GameObject:
   - component: {fileID: 1495294744}
   m_Layer: 0
   m_Name: Slot (5)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -15362,7 +15387,7 @@ GameObject:
   - component: {fileID: 1503007019}
   m_Layer: 0
   m_Name: Slot (3)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -16687,6 +16712,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: "\uAC80\uAE30"
+    ClassType: Warrior
     itemID: 11
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: ff81aacd3eb896d419ddf5171547b453, type: 3}
@@ -16718,6 +16744,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -17196,7 +17223,7 @@ GameObject:
   - component: {fileID: 1731701997}
   m_Layer: 0
   m_Name: Slot (9)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -17363,7 +17390,7 @@ GameObject:
   - component: {fileID: 1759154257}
   m_Layer: 0
   m_Name: Slot (3)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -17516,7 +17543,7 @@ GameObject:
   - component: {fileID: 1773590795}
   m_Layer: 0
   m_Name: Slot (6)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -17995,7 +18022,7 @@ GameObject:
   - component: {fileID: 1834979967}
   m_Layer: 0
   m_Name: Slot (8)
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -18147,7 +18174,7 @@ GameObject:
   - component: {fileID: 1846861473}
   m_Layer: 0
   m_Name: Slot
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -18951,7 +18978,7 @@ GameObject:
   - component: {fileID: 1880794652}
   m_Layer: 0
   m_Name: Slot
-  m_TagString: Slot
+  m_TagString: InherenceSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -18967,7 +18994,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 2, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 2003517537}
   m_Father: {fileID: 426573418}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -19027,7 +19055,7 @@ GameObject:
   - component: {fileID: 1893522832}
   m_Layer: 0
   m_Name: Slot (7)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -19103,7 +19131,7 @@ GameObject:
   - component: {fileID: 1903466285}
   m_Layer: 0
   m_Name: Slot (6)
-  m_TagString: Slot
+  m_TagString: AssassinSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -20007,7 +20035,7 @@ GameObject:
   - component: {fileID: 1976825715}
   m_Layer: 0
   m_Name: Slot (5)
-  m_TagString: Slot
+  m_TagString: WizardSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -20513,6 +20541,135 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2000883696}
   m_CullTransparentMesh: 1
+--- !u!1 &2003517536
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2003517537}
+  - component: {fileID: 2003517541}
+  - component: {fileID: 2003517540}
+  - component: {fileID: 2003517539}
+  - component: {fileID: 2003517538}
+  m_Layer: 0
+  m_Name: Item(Clone)
+  m_TagString: Item
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2003517537
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2003517536}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.2, y: 0.16666667, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 344985871}
+  - {fileID: 185339613}
+  - {fileID: 797853695}
+  m_Father: {fileID: 1880794651}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 40, y: 40}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2003517538
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2003517536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 50ae85c95785e694d8e55eb9067f21e5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  item:
+    itemName: "\uACE0\uC720 \uC2A4\uD0AC"
+    ClassType: 
+    itemID: 9
+    itemDesc: Text
+    itemIcon: {fileID: 21300000, guid: c2986e027f97f284dbe90a522238b6ea, type: 3}
+    itemModel: {fileID: 8936188002352116344, guid: 005bc3c502863684e85138a865b0ae55, type: 3}
+    itemValue: 1
+    itemType: 2
+    itemWeight: 0
+    maxStack: 99
+    indexItemInList: -1
+    rarity: 100
+    itemAttributes:
+    - attributeName: ATK
+      attributeValue: 80
+    - attributeName: CoolTime
+      attributeValue: 6
+    specialPrefabs: []
+    buffDatas: []
+--- !u!114 &2003517539
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2003517536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 551ac6c5596767544a4e04bdb7790f32, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  item:
+    itemName: 
+    ClassType: 
+    itemID: 0
+    itemDesc: 
+    itemIcon: {fileID: 0}
+    itemModel: {fileID: 0}
+    itemValue: 1
+    itemType: 0
+    itemWeight: 0
+    maxStack: 5
+    indexItemInList: 99
+    rarity: 0
+    itemAttributes: []
+    specialPrefabs: []
+    buffDatas: []
+  itemTypeOfSlot: 
+  duplication: {fileID: 0}
+--- !u!114 &2003517540
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2003517536}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 46874ca1f39c47447ad8a3b3733922f0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!225 &2003517541
+CanvasGroup:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2003517536}
+  m_Enabled: 1
+  m_Alpha: 1
+  m_Interactable: 1
+  m_BlocksRaycasts: 1
+  m_IgnoreParentGroups: 0
 --- !u!1 &2009942942
 GameObject:
   m_ObjectHideFlags: 0
@@ -20845,7 +21002,7 @@ GameObject:
   - component: {fileID: 2041939306}
   m_Layer: 0
   m_Name: Slot (5)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -21077,7 +21234,7 @@ GameObject:
   - component: {fileID: 2083364186}
   m_Layer: 0
   m_Name: Slot (2)
-  m_TagString: Slot
+  m_TagString: WarriorSlot
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
@@ -21856,7 +22013,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   slotsInTotal: 8
-  itemTypeOfSlots: 010000000100000001000000010000000a0000000a0000000a0000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
+  itemTypeOfSlots: 020000000100000001000000010000000a0000000a0000000a0000000a00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
 --- !u!224 &4151785054550245008
 RectTransform:
   m_ObjectHideFlags: 0
@@ -21980,7 +22137,7 @@ RectTransform:
   - {fileID: 1681356189}
   - {fileID: 2103092655}
   m_Father: {fileID: 654707144}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -22054,6 +22211,7 @@ MonoBehaviour:
   mainInventory: 1
   ItemsInInventory:
   - itemName: Buff_Tower
+    ClassType: 
     itemID: 7
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 3815db486757d6f419874d58bb1f364b, type: 3}
@@ -22080,6 +22238,7 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 01a591c01b353e94fb2982a91654c574, type: 2}
     - {fileID: 11400000, guid: 2a07d552522405747b505f2351bfbfc0, type: 2}
   - itemName: Guard_Tower
+    ClassType: 
     itemID: 4
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: c51f4ee40eac21346b6ea34182cf3465, type: 3}
@@ -22100,6 +22259,7 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: Cannon_Tower
+    ClassType: 
     itemID: 5
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 725f10fa9ac647d49a51f7de95f02b3d, type: 3}
@@ -22120,6 +22280,7 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: Minion_Tower
+    ClassType: 
     itemID: 6
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 127205e58a99ce04cab49b7eebb3f43b, type: 3}
@@ -22251,7 +22412,7 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 654707144}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -25449,7 +25610,7 @@ RectTransform:
   - {fileID: 4534138354803890094}
   - {fileID: 4534138355354579405}
   m_Father: {fileID: 654707144}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -26347,7 +26508,7 @@ RectTransform:
   - {fileID: 4764110604074843462}
   - {fileID: 4764110603165893781}
   m_Father: {fileID: 654707144}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
@@ -26368,6 +26529,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   item:
     itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}

--- a/Assets/심민섭/Resources/ItemDatabase.asset
+++ b/Assets/심민섭/Resources/ItemDatabase.asset
@@ -14,6 +14,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   itemList:
   - itemName: 
+    ClassType: 
     itemID: 0
     itemDesc: 
     itemIcon: {fileID: 0}
@@ -27,56 +28,9 @@ MonoBehaviour:
     itemAttributes: []
     specialPrefabs: []
     buffDatas: []
-  - itemName: Apple
-    itemID: 1
-    itemDesc: This apple could be good for applejuice.
-    itemIcon: {fileID: 21300000, guid: a4d3f378d1a88f346af15ee906321f2a, type: 3}
-    itemModel: {fileID: 100000, guid: 40da790cc27843b45b9c255c8d996b43, type: 3}
-    itemValue: 1
-    itemType: 2
-    itemWeight: 0
-    maxStack: 5
-    indexItemInList: 99
-    rarity: 100
-    itemAttributes:
-    - attributeName: Health
-      attributeValue: 10
-    specialPrefabs: []
-    buffDatas: []
-  - itemName: Iron Chest
-    itemID: 2
-    itemDesc: This chest is created out of iron.
-    itemIcon: {fileID: 21300000, guid: d13012f4abce7b241900001bf716f66e, type: 3}
-    itemModel: {fileID: 100000, guid: 40da790cc27843b45b9c255c8d996b43, type: 3}
-    itemValue: 1
-    itemType: 12
-    itemWeight: 0
-    maxStack: 1
-    indexItemInList: 99
-    rarity: 70
-    itemAttributes:
-    - attributeName: Health
-      attributeValue: 10
-    - attributeName: Armor
-      attributeValue: 20
-    specialPrefabs: []
-    buffDatas: []
-  - itemName: Applejuice
-    itemID: 3
-    itemDesc: This applejuice gives you alot of health back.
-    itemIcon: {fileID: 21300000, guid: 6dc5762501dd2df4da399f6c16a85907, type: 3}
-    itemModel: {fileID: 0}
-    itemValue: 0
-    itemType: 0
-    itemWeight: 0
-    maxStack: 0
-    indexItemInList: 0
-    rarity: 0
-    itemAttributes: []
-    specialPrefabs: []
-    buffDatas: []
   - itemName: Guard_Tower
-    itemID: 4
+    ClassType: 
+    itemID: 1
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: c51f4ee40eac21346b6ea34182cf3465, type: 3}
     itemModel: {fileID: 165880, guid: 8718cc0c9d623ed43803c6d0e6442df6, type: 3}
@@ -96,7 +50,8 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: Cannon_Tower
-    itemID: 5
+    ClassType: 
+    itemID: 2
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 725f10fa9ac647d49a51f7de95f02b3d, type: 3}
     itemModel: {fileID: 834644509087740589, guid: dfc26d37c6a9b6944900c89c4a87ffd7, type: 3}
@@ -116,7 +71,8 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: Minion_Tower
-    itemID: 6
+    ClassType: 
+    itemID: 3
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 127205e58a99ce04cab49b7eebb3f43b, type: 3}
     itemModel: {fileID: 8910650605806270272, guid: 6637d58b99c0eb747b6fc6af434505c8, type: 3}
@@ -139,7 +95,8 @@ MonoBehaviour:
     - {fileID: 0}
     buffDatas: []
   - itemName: Buff_Tower
-    itemID: 7
+    ClassType: 
+    itemID: 4
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 3815db486757d6f419874d58bb1f364b, type: 3}
     itemModel: {fileID: 7418510190786929041, guid: c700bba32eed8d34bb0e91144d9b33d5, type: 3}
@@ -165,7 +122,8 @@ MonoBehaviour:
     - {fileID: 11400000, guid: 01a591c01b353e94fb2982a91654c574, type: 2}
     - {fileID: 11400000, guid: 2a07d552522405747b505f2351bfbfc0, type: 2}
   - itemName: "\uB9C8\uAD6C\uD718\uB450\uB974\uAE30"
-    itemID: 8
+    ClassType: Warrior
+    itemID: 5
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: a49d70bc38fde7a4f95890a7ca766ef1, type: 3}
     itemModel: {fileID: 5184541198715492353, guid: af5d35f732b8aae4d8eefafd65b3078e, type: 3}
@@ -183,7 +141,8 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uB0B4\uB824\uCC0D\uAE30"
-    itemID: 9
+    ClassType: Warrior
+    itemID: 6
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 58e81ff14ea6c254db47989f2da77323, type: 3}
     itemModel: {fileID: 7570805014596217275, guid: ae48745f78ef46b478a6e9debebf5e0e, type: 3}
@@ -201,7 +160,8 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uD720\uC708\uB4DC"
-    itemID: 10
+    ClassType: Warrior
+    itemID: 7
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: 49b1324fe9983f44382c52acd0d35f20, type: 3}
     itemModel: {fileID: 3005192478522135544, guid: 1ff6e38d24d9fb74dbbca9b9d3c25117, type: 3}
@@ -219,7 +179,8 @@ MonoBehaviour:
     specialPrefabs: []
     buffDatas: []
   - itemName: "\uAC80\uAE30"
-    itemID: 11
+    ClassType: Warrior
+    itemID: 8
     itemDesc: Text
     itemIcon: {fileID: 21300000, guid: ff81aacd3eb896d419ddf5171547b453, type: 3}
     itemModel: {fileID: 8936188002352116344, guid: 005bc3c502863684e85138a865b0ae55, type: 3}
@@ -234,5 +195,24 @@ MonoBehaviour:
       attributeValue: 150
     - attributeName: CoolTime
       attributeValue: 8
+    specialPrefabs: []
+    buffDatas: []
+  - itemName: "\uACE0\uC720 \uC2A4\uD0AC"
+    ClassType: 
+    itemID: 9
+    itemDesc: Text
+    itemIcon: {fileID: 21300000, guid: c2986e027f97f284dbe90a522238b6ea, type: 3}
+    itemModel: {fileID: 8936188002352116344, guid: 005bc3c502863684e85138a865b0ae55, type: 3}
+    itemValue: 1
+    itemType: 2
+    itemWeight: 0
+    maxStack: 99
+    indexItemInList: 99
+    rarity: 100
+    itemAttributes:
+    - attributeName: ATK
+      attributeValue: 80
+    - attributeName: CoolTime
+      attributeValue: 6
     specialPrefabs: []
     buffDatas: []

--- a/Assets/심민섭/Scripts/Buttons/JobButtonImageChange.cs
+++ b/Assets/심민섭/Scripts/Buttons/JobButtonImageChange.cs
@@ -31,6 +31,12 @@ public class JobButtonImageChange : MonoBehaviour
         wizard.GetComponent<Image>().sprite = originalImageName;
         assassin.GetComponent<Image>().sprite = originalImageName;
         inherence.GetComponent<Image>().sprite = originalImageName;
+
+        // 전사 버튼을 누르면 장착 123슬롯의 테그를 변경한다.
+        for (int i = 1; i < 4; i++) // 1 ~ 3번, 세번 반복
+        {
+            GameObject.FindGameObjectWithTag("EquipmentSystem").transform.GetChild(1).GetChild(i).gameObject.tag = "WarriorSlot";
+        }
     }
 
     public void wizardButtonImageChange()
@@ -40,6 +46,11 @@ public class JobButtonImageChange : MonoBehaviour
         warrior.GetComponent<Image>().sprite = originalImageName;
         assassin.GetComponent<Image>().sprite = originalImageName;
         inherence.GetComponent<Image>().sprite = originalImageName;
+        // 마법사 버튼을 누르면 장착 123슬롯의 테그를 변경한다.
+        for (int i = 1; i < 4; i++) // 1 ~ 3번, 세번 반복
+        {
+            GameObject.FindGameObjectWithTag("EquipmentSystem").transform.GetChild(1).GetChild(i).gameObject.tag = "WizardSlot";
+        }
     }
 
     public void assassinButtonImageChange()
@@ -49,6 +60,11 @@ public class JobButtonImageChange : MonoBehaviour
         warrior.GetComponent<Image>().sprite = originalImageName;
         wizard.GetComponent<Image>().sprite = originalImageName;
         inherence.GetComponent<Image>().sprite = originalImageName;
+        // 암살자 버튼을 누르면 장착 123슬롯의 테그를 변경한다.
+        for (int i = 1; i < 4; i++) // 1 ~ 3번, 세번 반복
+        {
+            GameObject.FindGameObjectWithTag("EquipmentSystem").transform.GetChild(1).GetChild(i).gameObject.tag = "AssassinSlot";
+        }
     }
 
     public void inherenceButtonImageChange()

--- a/Assets/심민섭/Scripts/Inventory/Inventory/DragSlotsColorChange.cs
+++ b/Assets/심민섭/Scripts/Inventory/Inventory/DragSlotsColorChange.cs
@@ -68,6 +68,21 @@ public class DragSlotsColorChange : MonoBehaviour
             EquipmentArr[2].GetComponent<Image>().color = color;
             EquipmentArr[3].GetComponent<Image>().color = color;
         }
+        else if (itemOnObject.item.itemType.ToString() == "uniqueSkill")
+        {
+            // 스킬 타입이면 0 슬롯 변경
+            color = Color.yellow;
+            EquipmentArr[0].GetComponent<Image>().color = color;
+
+            color = Color.white;
+            EquipmentArr[1].GetComponent<Image>().color = color;
+            EquipmentArr[2].GetComponent<Image>().color = color;
+            EquipmentArr[3].GetComponent<Image>().color = color;
+            EquipmentArr[4].GetComponent<Image>().color = color;
+            EquipmentArr[5].GetComponent<Image>().color = color;
+            EquipmentArr[6].GetComponent<Image>().color = color;
+            EquipmentArr[7].GetComponent<Image>().color = color;
+        }
         else
         {
             return;

--- a/Assets/심민섭/Scripts/Inventory/Items/DragItem.cs
+++ b/Assets/심민섭/Scripts/Inventory/Items/DragItem.cs
@@ -67,8 +67,6 @@ public class DragItem : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDr
         inventory.OnUpdateItemList();
     }
 
-
-
     public void OnPointerDown(PointerEventData data)
     {
         if (data.button == PointerEventData.InputButton.Left)
@@ -100,33 +98,47 @@ public class DragItem : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDr
 
             if (newSlot != null)
             {
-                //getting the items from the slots, GameObjects and RectTransform
+                // 내 게임 오브젝트(Slot)
                 GameObject firstItemGameObject = this.gameObject;
+                // 마우스 포인터의 상위 게임 오브젝트(Slots)
                 GameObject secondItemGameObject = newSlot.parent.gameObject;
+                // 내 게임 오브젝트 위치
                 RectTransform firstItemRectTransform = this.gameObject.GetComponent<RectTransform>();
+                // 마우스 포인터의 상위 게임 오브젝트 위치
                 RectTransform secondItemRectTransform = newSlot.parent.GetComponent<RectTransform>();
+                // 들고 있는 아이템의 정보
                 Item firstItem = rectTransform.GetComponent<ItemOnObject>().item;
+                // 새로운 곳에 만들 아이템 공간
                 Item secondItem = new Item();
+                // 새로운 곳에 만들 아이템 공간에 이미 아이템이 존재하다면 아이템을 서로 바꿔치기한다.
                 if (newSlot.parent.GetComponent<ItemOnObject>() != null)
                     secondItem = newSlot.parent.GetComponent<ItemOnObject>().item;
 
-                //get some informations about the two items
+                //Debug.Log($"newSlot : {newSlot.tag}");
+                //Debug.Log($"oldSlot : {oldSlot.tag}");
+
+                // 현재 아이템과 타겟 아이템의 이름이 같은가?
                 bool sameItem = firstItem.itemName == secondItem.itemName;
+                // 참조를 제외하고 값만을 다시 비교한다.
                 bool sameItemRerferenced = firstItem.Equals(secondItem);
                 bool secondItemStack = false;
                 bool firstItemStack = false;
+                // 이름이 같다면
                 if (sameItem)
                 {
+                    // 아이템의 수를 비교 (1 < 99)
                     firstItemStack = firstItem.itemValue < firstItem.maxStack;
                     secondItemStack = secondItem.itemValue < secondItem.maxStack;
                 }
 
+                // 마우스 포인터의 상위 게임 오브젝트 위치에서 상위 오브젝트를 저장
+                // 일반적으로 Viewport, Equipment - panel
                 GameObject Inventory = secondItemRectTransform.parent.gameObject;
-                if (Inventory.tag == "Slot")
-                    Inventory = secondItemRectTransform.parent.parent.parent.gameObject;
+                if (Inventory.tag == "Slot" || newSlot.tag == oldSlot.tag)
+                    Inventory = secondItemRectTransform.parent.parent.parent.gameObject; // Panel - Card
 
-                if (Inventory.tag.Equals("Slot"))
-                    Inventory = Inventory.transform.parent.parent.gameObject;
+                if (Inventory.tag.Equals("Slot") || oldSlot.tag.Equals(newSlot.tag))
+                    Inventory = Inventory.transform.parent.parent.gameObject; // Panel - Card
 
                 //dragging in an Inventory      
                 if (Inventory.GetComponent<EquipmentSystem>() == null && Inventory.GetComponent<CraftSystem>() == null)
@@ -244,11 +256,9 @@ public class DragItem : MonoBehaviour, IDragHandler, IPointerDownHandler, IEndDr
                             }
 
                         }
-
-                        //empty slot
                         else
                         {
-                            if (newSlot.tag != "Slot" && newSlot.tag != "ItemIcon")
+                            if (newSlot.tag != "Slot" && newSlot.tag != "ItemIcon" && oldSlot.tag != newSlot.tag || newSlot.tag != firstItem.ClassType + "Slot")
                             {
                                 firstItemGameObject.transform.SetParent(oldSlot.transform);
                                 firstItemRectTransform.localPosition = Vector3.zero;

--- a/Assets/심민섭/Scripts/Inventory/Items/Item.cs
+++ b/Assets/심민섭/Scripts/Inventory/Items/Item.cs
@@ -19,6 +19,7 @@ using System.Collections.Generic;
 public class Item
 {
     public string itemName;                     // 아이템 이름
+    public string ClassType;                    // 직업 타입
     public int itemID;                          // 아이템의 만들어 진 순서 (Index)
     public string itemDesc;                     // 아이템 설명
     public Sprite itemIcon;                     // 아이템 이미지

--- a/Assets/심민섭/Scripts/Inventory/Items/ItemType.cs
+++ b/Assets/심민섭/Scripts/Inventory/Items/ItemType.cs
@@ -5,7 +5,7 @@ public enum ItemType        //all ItemTypes...you can add some
 {
     None = 0,
     Skill = 1,
-    Consumable = 2,
+    uniqueSkill = 2,
     Quest = 3,
     Head = 4,
     Shoe = 5,

--- a/Assets/심민섭/Scripts/Inventory/Items/TrojanHorse.cs
+++ b/Assets/심민섭/Scripts/Inventory/Items/TrojanHorse.cs
@@ -84,7 +84,7 @@ public class TrojanHorse: MonoBehaviour
         //ItemOnObject에서 가져온다.
 
         // 장착 슬롯 오브젝트 가져오기
-        EquipmentItemInventory = GameObject.FindGameObjectWithTag("Inventory").transform.GetChild(0).GetChild(1).GetChild(1).GetChild(1).GetChild(1).GetChild(1).gameObject;
+        EquipmentItemInventory = GameObject.FindGameObjectWithTag("Inventory").transform.GetChild(0).GetChild(2).GetChild(1).GetChild(1).GetChild(1).GetChild(1).gameObject;
 
         // 하위 오브젝트들을 리스트에 넣는다.
         List<GameObject> TrojanDataList= new List<GameObject>();

--- a/Assets/심민섭/Textures/SkillCard/Start.JPG.meta
+++ b/Assets/심민섭/Textures/SkillCard/Start.JPG.meta
@@ -6,7 +6,7 @@ TextureImporter:
   serializedVersion: 11
   mipmaps:
     mipMapMode: 0
-    enableMipMap: 1
+    enableMipMap: 0
     sRGBTexture: 1
     linearTexture: 0
     fadeOut: 0
@@ -36,13 +36,13 @@ TextureImporter:
     filterMode: 1
     aniso: 1
     mipBias: 0
-    wrapU: 0
-    wrapV: 0
+    wrapU: 1
+    wrapV: 1
     wrapW: 0
-  nPOTScale: 1
+  nPOTScale: 0
   lightmap: 0
   compressionQuality: 50
-  spriteMode: 0
+  spriteMode: 1
   spriteExtrude: 1
   spriteMeshType: 1
   alignment: 0
@@ -51,9 +51,9 @@ TextureImporter:
   spriteBorder: {x: 0, y: 0, z: 0, w: 0}
   spriteGenerateFallbackPhysicsShape: 1
   alphaUsage: 1
-  alphaIsTransparency: 0
+  alphaIsTransparency: 1
   spriteTessellationDetail: -1
-  textureType: 0
+  textureType: 8
   textureShape: 1
   singleChannelComponent: 0
   flipbookRows: 1
@@ -76,13 +76,61 @@ TextureImporter:
     overridden: 0
     androidETC2FallbackOverride: 0
     forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Server
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Android
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: WebGL
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
   spriteSheet:
     serializedVersion: 2
     sprites: []
     outline: []
     physicsShape: []
     bones: []
-    spriteID: 
+    spriteID: 5e97eb03825dee720800000000000000
     internalID: 0
     vertices: []
     indices: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -46,6 +46,10 @@ TagManager:
   - Zera
   - Dappx
   - Tag
+  - WarriorSlot
+  - WizardSlot
+  - AssassinSlot
+  - InherenceSlot
   layers:
   - Default
   - TransparentFX


### PR DESCRIPTION
- WarriorSlot ... 외 tag 3개 추가
- 고유 스킬 장착 칸 분류(색상 변경, 고유 스킬 추가(임시) 등)
- 인벤토리 분류 ex) 전사 카드는 타 직업의 인벤토리에 넣을 수 없음.
     타워 카드는 스킬 카드 인벤토리에 넣을 수 없음.
- itemdatabase 스크럽터블 오브젝트 데이터 수정(index, classtype 추가)